### PR TITLE
Add notify() function to .bashrc

### DIFF
--- a/config/dotfiles/bashrc
+++ b/config/dotfiles/bashrc
@@ -34,6 +34,13 @@ else
   echo "$(tput setaf 1)Can't find a home or work config file$(tput sgr 0)"
 fi
 
+#######################################
+# Executes the specified command. Alerts the user when the command completes.
+# Arguments:
+#   Command to execute
+# Returns:
+#   None
+#######################################
 notify() {
   local title="Succeeded"
   # Capture the parameter list for later display.

--- a/config/dotfiles/bashrc
+++ b/config/dotfiles/bashrc
@@ -33,3 +33,25 @@ elif [[ -f "$CONFIG_HOME" ]]; then
 else
   echo "$(tput setaf 1)Can't find a home or work config file$(tput sgr 0)"
 fi
+
+notify() {
+  local title="Succeeded"
+  # Capture the parameter list for later display.
+  local message=$@
+
+  if [[ $# -eq 0 ]]; then
+    return
+  fi
+
+  # Execute the parameters.
+  eval $@
+
+  # Get the exit status of the last-run command.
+  local retVal=$?
+  if [[ $retVal -ne 0 ]]; then
+    title="Failed"
+  fi
+
+  # Notify the user that the command is done.
+  terminal-notifier -title "$title" -message "$message" -sound "default" -ignoreDnD
+}


### PR DESCRIPTION
The setup script already installs `terminal-notifier`, which is a prerequisite.

This was written by @dfed with minimal modification. Thanks Dan!