### PR TITLE
Fix `git rbm`

### DIFF
--- a/config/dotfiles/gitconfig
+++ b/config/dotfiles/gitconfig
@@ -11,8 +11,9 @@
   p = push
   pf = push --force-with-lease
   pnv = push --no-verify
-  # Rebase the current branch over origin/master
-  rbm = pull --rebase origin master
+  # Rebase the current branch over where it branched from master.
+  # TODO: Change to main.
+  rbm = rebase -i $(git merge-base HEAD origin/master)
   superclean = clean -fxd
 [color]
   ui = auto

--- a/config/dotfiles/gitconfig
+++ b/config/dotfiles/gitconfig
@@ -19,7 +19,6 @@
 [core]
   excludesfile = ~/.gitignore_global
 	precomposeunicode = true
-	sparseCheckout = true
 	ignorecase = false
 	untrackedCache = true
 [push]
@@ -41,7 +40,10 @@
   prompt = false
 [diff]
   tool = Kaleidoscope
+  renameLimit = 10000
 [rerere]
 	enabled = false
 [pull]
 	ff = only
+[url "ssh://git@git.musta.ch/"]
+	insteadOf = https://git.musta.ch/


### PR DESCRIPTION
I have a handy helper to rebase the current branch over where you branched off of the master branch. The logic I had written would work most of the time but not all of the time. I learned about the merge-base command at work. Using the merge-base command fixes `git rbm` for my current branch at work. **Update:** The command worked but the git alias didn't. See https://github.com/bachand/battlestation/pull/14.

While I was here I committed other generalizable changes from my work machine.