### PR TITLE
Use `rbi` instead of `git rbm`

### DIFF
--- a/config/dotfiles/aliases.zsh
+++ b/config/dotfiles/aliases.zsh
@@ -17,3 +17,7 @@ alias s3='aws s3'
 
 # Apple says that anything requiring a developer to delete `DerivedData` is a serious bug in Xcode.
 alias rmdd="echo I\'m sorry `id -un`, I\'m afraid I can\'t do that"
+
+# Rebase the current branch over where it branched from master.
+# TODO: Change to main.
+alias rbi="git rebase -i \$(git merge-base HEAD origin/master)"

--- a/config/dotfiles/gitconfig
+++ b/config/dotfiles/gitconfig
@@ -11,9 +11,6 @@
   p = push
   pf = push --force-with-lease
   pnv = push --no-verify
-  # Rebase the current branch over where it branched from master.
-  # TODO: Change to main.
-  rbm = rebase -i $(git merge-base HEAD origin/master)
   superclean = clean -fxd
 [color]
   ui = auto


### PR DESCRIPTION
This is a follow up to https://github.com/bachand/battlestation/pull/12. I couldn't get my git alias to invoke git successfully. I have been using `rbi` at work which stands for "rebase interaction" as I recall.