### PR TITLE
Add back `git rbm`

### DIFF
--- a/config/dotfiles/gitconfig
+++ b/config/dotfiles/gitconfig
@@ -12,6 +12,8 @@
   pf = push --force-with-lease
   pnv = push --no-verify
   superclean = clean -fxd
+  # Rebase the current branch over origin/master
+  rbm = pull --rebase origin master
 [color]
   ui = auto
 [core]


### PR DESCRIPTION
This PR follows https://github.com/bachand/battlestation/pull/12 and https://github.com/bachand/battlestation/pull/14. I got confused and `rbi` was not interchangeable with `git rbm`. `git rbm` is useful for rebasing the current branch over master.