### PR TITLE
Move Homebrew setup to .zshrc

### DIFF
--- a/config/dotfiles/zshenv
+++ b/config/dotfiles/zshenv
@@ -23,13 +23,6 @@ readonly BATTLESTATION_ROOT="$PARENT_DIR/../.."
 
 source "$PARENT_DIR/../../lib/functions.zsh"
 
-# Homebrew
-if is_silicon_mac
-then
-  eval "$(/opt/homebrew/bin/brew shellenv)"
-else
-  eval "$(/usr/local/bin/brew shellenv)"
-fi
 # Python
 path+="$HOME/Library/Python/3.6/bin"
 # https://github.com/bachand/battlestation

--- a/config/dotfiles/zshrc
+++ b/config/dotfiles/zshrc
@@ -1,5 +1,14 @@
 #! /usr/bin/env zsh
 
+## Homebrew
+
+if is_silicon_mac
+then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+else
+  eval "$(/usr/local/bin/brew shellenv)"
+fi
+
 ## History
 
 # For more information on history, see https://wiki.gentoo.org/wiki/Zsh/Guide#History and


### PR DESCRIPTION
I've been seeing these errors when opening my terminal.

<img width="964" alt="Screenshot 2023-05-23 at 9 19 47 PM" src="https://github.com/bachand/battlestation/assets/1791049/cd46ad4a-38c3-4c6f-9143-86a35657a174">

I noticed when running `which git` that I was using system Git. I traced this down to how my `PATH` was set up.

Between the end of the execution of .zshenv and the start of execution of .zshrc, macOS appears to update the `PATH`. Although I would prefer to set up the `PATH` variable to prefer Homebrew binaries in my .zshenv, moving this setup to .zshrc fixes the permissions issue.
