### PR TITLE
Disable automatic inline suggestions in Github Copilot

### DIFF
--- a/config/vscode_settings.json
+++ b/config/vscode_settings.json
@@ -27,6 +27,7 @@
     "markdown": false,
     "scminput": false
   },
+  "github.copilot.editor.enableAutoCompletions": false,
   // Disable quick suggestions for plaintext files.
   "[plaintext]": {
     "editor.quickSuggestions": {


### PR DESCRIPTION
I find Github Copilot suggestions useful but they can also be distracting, especially when writing comments. If I could turn off automatic suggestions for only comments I would do that. Since that's not possible, I'm turning of automatic inline suggestions overall. I can trigger them manually with the [keyboard shortcuts](https://docs.github.com/en/copilot/configuring-github-copilot/configuring-github-copilot-in-your-environment?tool=vscode#keyboard-shortcuts-for-macos-1).