### PR TITLE
macOS CI, gardening, and various small fixups

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,12 +14,23 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
-
+  test-linux:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Ruby
+      # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+      # (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rspec
+
+  test-mac:
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
       # (see https://github.com/ruby/setup-ruby#versioning):

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,7 +28,7 @@ jobs:
       run: bundle exec rspec
 
   test-mac:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # My Battlestation
 
-Inspired by https://www.reddit.com/r/battlestations/. Spoiler alert: my actual battlestation is much less cool than any of these :stuck_out_tongue:
+Inspired by https://www.reddit.com/r/battlestations/.
 
 ## Setting up
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,3 @@ $ git clone https://github.com/bachand/battlestation.git
 $ cd battlestation
 $ ./bin/battlestation setup
 ```
-
-## Gotchas
-
-- [`setup`](bin/setup) must be run from a directory underneath this repo.

--- a/config/dotfiles/aliases.zsh
+++ b/config/dotfiles/aliases.zsh
@@ -12,9 +12,6 @@ alias cdr="cd $HOME/repos"
 alias sn='code'
 alias v='vim'
 
-alias cloudformation='aws cloudformation'
-alias s3='aws s3'
-
 # Apple says that anything requiring a developer to delete `DerivedData` is a serious bug in Xcode.
 alias rmdd="echo I\'m sorry `id -un`, I\'m afraid I can\'t do that"
 

--- a/lib/battlestation/cli.rb
+++ b/lib/battlestation/cli.rb
@@ -88,8 +88,7 @@ defaults write com.apple.dt.Xcode DVTTextPageGuideLocation -int 100
     end
 
     def run_legacy_setup_script(current_dirname)
-      setup_path = File.join current_dirname, '../../bin/setup'
-      system 'bash', '-c', setup_path
+      Dir.chdir(current_dirname) { system 'bash', '-c', '../../bin/setup' }
     end
 
     def update_homebrew

--- a/lib/battlestation/cli.rb
+++ b/lib/battlestation/cli.rb
@@ -88,6 +88,8 @@ defaults write com.apple.dt.Xcode DVTTextPageGuideLocation -int 100
     end
 
     def run_legacy_setup_script(current_dirname)
+      # The legacy setup script must be executed from a working directory within the repo to support
+      # using Git to determine the root directory of the repository.
       Dir.chdir(current_dirname) { system 'bash', '-c', '../../bin/setup' }
     end
 

--- a/todo.md
+++ b/todo.md
@@ -1,4 +1,4 @@
-- Make Sublime text the default way to open .txt, .md, etc. files
+- Make VS Code the default way to open .txt, .md, etc. files
 - Add a git command to delete all local branches not matching a regex. This would be useful for deleting all local branches that don't contain my prefix, `mb-`.
 - Figure out a way to not have to run `bundle install` as an admin. Should the first thing that `battlestation` does be install `rbenv`/`rvm`? Or should we specify a path for bundler to install to?
 - Add home folder to Finder sidebar

--- a/todo.md
+++ b/todo.md
@@ -1,4 +1,3 @@
-- Integrate with Travis
 - Make Sublime text the default way to open .txt, .md, etc. files
 - Add a git command to delete all local branches not matching a regex. This would be useful for deleting all local branches that don't contain my prefix, `mb-`.
 - Figure out a way to not have to run `bundle install` as an admin. Should the first thing that `battlestation` does be install `rbenv`/`rvm`? Or should we specify a path for bundler to install to?

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,5 @@
 - Make VS Code the default way to open .txt, .md, etc. files
-- Add a git command to delete all local branches not matching a regex. This would be useful for deleting all local branches that don't contain my prefix, `mb-`.
+- Add a git command to delete all local branches not matching a regex. This would be useful for deleting all local branches that don't contain a prefix like `mb-`.
 - Figure out a way to not have to run `bundle install` as an admin. Should the first thing that `battlestation` does be install `rbenv`/`rvm`? Or should we specify a path for bundler to install to?
 - Add home folder to Finder sidebar
 - Add https://youtu.be/St2jUxnCVKI?t=29s


### PR DESCRIPTION
In addition to smaller changes, Ruby tests now run in CI on macOS and I removed a gotcha from the README through a code change.

### Testing

- [x] Run `./bin/battlestation setup` locally

I ran this command twice on my M1 Max MacBook Pro. The command made updates during the first run and performed fewer steps in the second run, as expected.

There are a couple of issues during the beginning of the setup process that I will address in a future PR, as they are unrelated to this change.

<img width="1299" alt="Screenshot 2024-07-02 at 4 56 57 PM" src="https://github.com/bachand/battlestation/assets/1791049/e4d1d9c4-ff9c-47e0-89b3-df04be8ff947">
