### PR TITLE
Update VS Code settings regarding GitHub Copilot inline suggestions

### DIFF
--- a/config/vscode_settings.json
+++ b/config/vscode_settings.json
@@ -22,12 +22,8 @@
   "workbench.colorTheme": "Visual Studio Dark",
   "window.zoomLevel": 1,
   "github.copilot.enable": {
-    "*": true,
-    "plaintext": false,
-    "markdown": false,
-    "scminput": false
+    "*": false
   },
-  "github.copilot.editor.enableAutoCompletions": false,
   // Disable quick suggestions for plaintext files.
   "[plaintext]": {
     "editor.quickSuggestions": {


### PR DESCRIPTION
VS Code informed me that `github.copilot.editor.enableAutoCompletions` is now obsolete. I updated my settings to use the recommended alternative.

<img width="631" alt="Screenshot 2025-05-20 at 6 50 39 PM" src="https://github.com/user-attachments/assets/0a7a0692-c9c9-43a2-a468-5cfc25ce2398" />

I like triggering Copilot manually but prefer not to have automatic inline suggestions.