### PR TITLE
Remove `readonly` from variables in .zshrc

### DIFF
--- a/config/dotfiles/zshrc
+++ b/config/dotfiles/zshrc
@@ -68,8 +68,8 @@ fi
 
 ## Machine-specific configuration
 
-readonly CONFIG_WORK="$HOME/Google Drive/My Drive/dotfiles/airbnb"
-readonly CONFIG_HOME="$HOME/Dropbox/dotfiles/home"
+CONFIG_WORK="$HOME/Google Drive/My Drive/dotfiles/airbnb"
+CONFIG_HOME="$HOME/Dropbox/dotfiles/home"
 
 if [[ -f "$CONFIG_WORK" ]]; then
   source "$CONFIG_WORK"


### PR DESCRIPTION
The `readonly` nature of the variables prevents the .zshrc file from being sourced after it's already been loaded. `source ~/.zshrc` results in the error `.zshrc:71: read-only variable: CONFIG_WORK`.