### PR TITLE
Improve Homebrew package installation and remove unused packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'rake'
 gem 'rubocop', '~> 0.49.1', require: false
 gem 'rspec'
 gem 'aws-sdk-s3', '~> 1'
+gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    colorize (1.1.0)
     diff-lcs (1.5.0)
     jmespath (1.6.1)
     parallel (1.22.1)
@@ -55,6 +56,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3 (~> 1)
+  colorize
   rake
   rspec
   rubocop (~> 0.49.1)

--- a/lib/battlestation/cli.rb
+++ b/lib/battlestation/cli.rb
@@ -31,7 +31,7 @@ module Battlestation
 
       update_homebrew()
 
-      install_packages(current_dirname)
+      install_packages()
 
       configure_fzf()
 
@@ -120,7 +120,7 @@ fi
 }
     end
 
-    def install_packages(_current_dirname)
+    def install_packages()
       packages = [
         'cloc',
         'exiftool',

--- a/lib/battlestation/cli.rb
+++ b/lib/battlestation/cli.rb
@@ -4,6 +4,7 @@ require 'pathname'
 require 'tmpdir'
 
 require_relative '../output'
+require 'colorize'
 
 module Battlestation
 
@@ -119,9 +120,8 @@ fi
 }
     end
 
-    def install_packages(current_dirname)
+    def install_packages(_current_dirname)
       packages = [
-        'ag',
         'cloc',
         'exiftool',
         'ffmpeg',
@@ -133,45 +133,24 @@ fi
         'ios-sim',
         'python',
         'rbenv',
-        'terminal-notifier',
-        'youtube-dl',
         'gh',
       ]
-      # Slowly bringing code into ruby from the monolithic setup script.
-      system 'bash', '-c', %{
-#######################################
-# Prints the provided message to STDOUT in green.
-#
-# Arguments:
-#   Info message
-#######################################
-echo_info() {
-  printf "$(tput setaf 2)%s$(tput sgr 0)\n" "$*" >&2;
-}
 
-#######################################
-# Installs the specified Homebrew package if it isn't installed. If it is, tries to upgrade the
-# package.
-#
-# Arguments:
-#   Name of package
-#######################################
-install_or_upgrade_package() {
-  if ! #{full_homebrew_path} list "$1" >/dev/null 2>&1; then
-    echo_info "Installing $1 via Homebrew"
-    #{full_homebrew_path} install "$1"
-  else
-    # TODO: find a way to only update if needed to prevent errors in console.
-    #{full_homebrew_path} upgrade "$1"
-  fi
-}
-
-packages=( #{packages.join(" ")} )
-for package in "${packages[@]}"
-do
-  install_or_upgrade_package "$package"
-done
-      }
+      for package in packages
+        if system(full_homebrew_path, 'list', package, out: File::NULL, err: File::NULL)
+          # Package is installed. Only update it if it's outdated.
+          outdated = system(full_homebrew_path, 'outdated', package, out: File::NULL, err: File::NULL)
+          if !outdated
+            puts "Upgrading #{package} via Homebrew".colorize(:green)
+            system(full_homebrew_path, 'upgrade', package)
+          else
+            puts "#{package} is up to date.".colorize(:light_black)
+          end
+        else
+          puts "Installing #{package} via Homebrew".colorize(:green)
+          system(full_homebrew_path, 'install', package)
+        end
+      end
     end
 
     # Runs the fzf install script in order to install key bindings and shell completion.


### PR DESCRIPTION
cli.b was calling older Bash code. I've ported the logic to install Homebrew packages in Ruby.

I ran `./bin/battlestation setup` and saw that packages were not upgraded when there wasn't a newer version.

<img width="255" height="225" alt="Screenshot 2025-08-23 at 7 10 53 PM" src="https://github.com/user-attachments/assets/8d093640-9bda-4239-8278-07edf6f9c8c2" />
