### PR TITLE
Setup creates machine-specific git identity file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Clone the repo and run the setup command.
 ```shell
 $ git clone https://github.com/bachand/battlestation.git
 $ cd battlestation
-$ ./bin/battlestation setup
+$ ./bin/battlestation setup --git-email you@example.com
 ```

--- a/bin/battlestation
+++ b/bin/battlestation
@@ -4,6 +4,16 @@
 $LOAD_PATH.unshift("#{__dir__}/../lib")
 
 require 'battlestation'
+require_relative '../lib/output'
 
-cli = Battlestation::CLI.new
-cli.run
+begin
+	cli = Battlestation::CLI.new
+	cli.run(ARGV)
+rescue StandardError => e
+	if ENV['BATTLESTATION_DEBUG'] == '1'
+		Output.put_debug(e.full_message)
+	else
+		Output.put_error(e.message)
+	end
+	exit 1
+end

--- a/bin/setup
+++ b/bin/setup
@@ -84,6 +84,5 @@ create_link "$HOME/Library/Application Support/Code/User/settings.json" "$CONFIG
 
 
 chmod 755 "$REPO_DIR/bin/git-cleanup"
-create_link '/usr/local/bin/git-cleanup' "$REPO_DIR/bin/git-cleanup"
 
 exit 1

--- a/config/dotfiles/gitconfig
+++ b/config/dotfiles/gitconfig
@@ -25,6 +25,9 @@
 	default = current
 [user]
 	name = Michael Bachand
+[include]
+	# Linked by setup to the local per-machine identity file.
+	path = ~/.gitconfig-identity
 [credential]
 	helper = osxkeychain
 [mergetool "Kaleidoscope"]

--- a/config/dotfiles/gitconfig
+++ b/config/dotfiles/gitconfig
@@ -26,7 +26,7 @@
 [user]
 	name = Michael Bachand
 [include]
-	# Linked by setup to the local per-machine identity file.
+	# This per-machine identity file is written during setup.
 	path = ~/.gitconfig-identity
 [credential]
 	helper = osxkeychain

--- a/lib/battlestation/cli.rb
+++ b/lib/battlestation/cli.rb
@@ -29,6 +29,8 @@ module Battlestation
 
       configure_xcode()
 
+      identity_write_action.write_if_needed
+
       run_legacy_setup_script(current_dirname)
 
       install_python()
@@ -50,8 +52,6 @@ module Battlestation
 
       install_gems(current_dirname)
 
-      identity_write_action.write_if_needed
-
       Output.put_success("Setup completed.")
       Output.put_info("Please close and reopen your shell.")
     end
@@ -59,7 +59,7 @@ module Battlestation
     private
 
     def parse_options(args)
-      options = { git_email: nil }
+      options = { }
 
       parser = OptionParser.new do |opts|
         opts.banner = 'Usage: ./bin/battlestation setup [--git-email email@example.com]'

--- a/lib/battlestation/git_identity.rb
+++ b/lib/battlestation/git_identity.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Battlestation
+  # Validates and writes the per-machine Git identity file.
+  # The write action lets us validate early and write later.
+  class GitIdentity
+    # Deferred write for the identity file. Use after the rest of setup succeeds.
+    class WriteAction
+      def initialize(path, should_write, git_email)
+        @path = path
+        @should_write = should_write
+        @git_email = git_email
+      end
+
+      # Writes the identity file only when it is missing.
+      # The email is expected to be validated before creating the action.
+      def write_if_needed
+        return unless @should_write
+        File.write(@path, <<~GITCONFIG)
+          [user]
+            email = #{@git_email}
+        GITCONFIG
+      end
+    end
+
+    # @param path [String] path to the per-machine identity file.
+    def initialize(path = File.expand_path('~/.gitconfig-identity'))
+      @path = path
+    end
+
+    # Validates that an email is present when the identity file is missing, and
+    # returns a write action to run later in the setup flow.
+    # @param git_email [String, nil]
+    # @return [WriteAction]
+    def validate_and_plan_write(git_email)
+      identity_file_exists = File.exist?(@path)
+      if !identity_file_exists && (git_email.nil? || git_email.empty?)
+        raise ArgumentError, "Email is required. Run: ./bin/battlestation setup --git-email you@example.com"
+      end
+
+      WriteAction.new(@path, !identity_file_exists, git_email)
+    end
+  end
+end

--- a/lib/battlestation/git_identity.rb
+++ b/lib/battlestation/git_identity.rb
@@ -34,11 +34,9 @@ module Battlestation
     # @return [WriteAction]
     def validate_and_plan_write(git_email)
       git_email = sanitize_email(git_email)
-      raise ArgumentError, "Invalid email format: #{git_email}" unless git_email
-
       identity_file_exists = File.exist?(@path)
-      if !identity_file_exists && (git_email.nil? || git_email.empty?)
-        raise ArgumentError, "Email is required. Run: ./bin/battlestation setup --git-email you@example.com"
+      if !identity_file_exists && !git_email
+        raise 'Valid email is required. Run: ./bin/battlestation setup --git-email you@example.com'
       end
 
       WriteAction.new(@path, !identity_file_exists, git_email)

--- a/lib/battlestation/git_identity.rb
+++ b/lib/battlestation/git_identity.rb
@@ -33,12 +33,22 @@ module Battlestation
     # @param git_email [String, nil]
     # @return [WriteAction]
     def validate_and_plan_write(git_email)
+      git_email = sanitize_email(git_email)
+      raise ArgumentError, "Invalid email format: #{git_email}" unless git_email
+
       identity_file_exists = File.exist?(@path)
       if !identity_file_exists && (git_email.nil? || git_email.empty?)
         raise ArgumentError, "Email is required. Run: ./bin/battlestation setup --git-email you@example.com"
       end
 
       WriteAction.new(@path, !identity_file_exists, git_email)
+    end
+
+    def sanitize_email(git_email)
+      return nil if git_email.nil?
+
+      sanitized = git_email.strip
+      sanitized.empty? ? nil : sanitized
     end
   end
 end

--- a/lib/output.rb
+++ b/lib/output.rb
@@ -1,9 +1,9 @@
 # Functions for outputting various types of messages to the user.
-
+# Reserve STDOUT for system output.
 module Output
 
   def self.put_success(text)
-    $stdout.puts "\e[0;32m" + text + "\e[0m"
+    $stderr.puts "\e[0;32m" + text + "\e[0m"
   end
 
   def self.put_error(text)
@@ -11,6 +11,10 @@ module Output
   end
 
   def self.put_info(text)
-    $stdout.puts "\e[0m" + text + "\e[0m"
+    $stderr.puts "\e[0m" + text + "\e[0m"
+  end
+
+  def self.put_debug(text)
+    $stderr.puts text
   end
 end

--- a/spec/battlestation/cli_spec.rb
+++ b/spec/battlestation/cli_spec.rb
@@ -5,8 +5,15 @@ describe Battlestation::CLI do
 
   describe '#run' do
     it 'runs each setup step and returns shell exit status' do
+      identity = instance_double(Battlestation::GitIdentity)
+      expect(Battlestation::GitIdentity).to receive(:new).and_return(identity)
+
+      identity_action = instance_double(Battlestation::GitIdentity::WriteAction)
+      expect(identity).to receive(:validate_and_plan_write).with('dev@example.com').and_return(identity_action)
+
       expect(subject).to receive(:install_terminal_theme).with(kind_of(Pathname))
       expect(subject).to receive(:configure_xcode)
+      expect(identity_action).to receive(:write_if_needed)
       expect(subject).to receive(:run_legacy_setup_script).with(kind_of(Pathname))
       expect(subject).to receive(:install_python)
       expect(subject).to receive(:install_aws_cli)
@@ -20,7 +27,7 @@ describe Battlestation::CLI do
       allow(Output).to receive(:put_success)
       allow(Output).to receive(:put_info)
 
-      subject.run
+      subject.run(['--git-email', 'dev@example.com'])
     end
   end
 end


### PR DESCRIPTION
When running setup, we now create a ~/.gitconfig-identity file that includes the preferred email address. The .gitconfig checked into the repo doesn't include an email address, since I leverage this code in different environments (work and home).

My primary motivation for adding this feature is so that Xcode can see my git identity to facilitate using source control features in Xcode.

## Tests

- [x] Ran setup with my email and I observed that the identity file is written and it reflects in Xcode

| Before | After |
| ---- | ---- |
| <img width="822" height="564" alt="Screenshot 2026-02-08 at 12 21 15 PM" src="https://github.com/user-attachments/assets/46d5f3f3-a362-439c-b630-d1a8533079ca" /> |  <img width="822" height="564" alt="Screenshot_2026-02-08_at_12_49_36 PM" src="https://github.com/user-attachments/assets/0adff1c8-20ec-4022-a76e-0fba02a4fda8" /> |

- [x] Ran setup again without an email and observed that it succeeded since there was already an identify file